### PR TITLE
fix: use script command to allocate PTY for tmux tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,4 @@ jobs:
         run: just lint
 
       - name: Test
-        run: just test
+        run: script -q -e -c "just test" /dev/null


### PR DESCRIPTION
## Summary
- Use `script -q -e -c "just test" /dev/null` to allocate a PTY for pytest in CI
- This allows tmux to work properly since it requires a terminal
- Alternative to skipping tmux tests in CI environments

## Test plan
- [ ] Verify CI passes with tmux tests running (not skipped)
- [ ] Check that test output is clean (no script artifacts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)