### PR TITLE
fix: use unbuffer to allocate PTY for tmux tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
       - name: Install just
         uses: extractions/setup-just@v2
 
-      - name: Install tmux
-        run: sudo apt-get update && sudo apt-get install -y tmux
+      - name: Install tmux and expect
+        run: sudo apt-get update && sudo apt-get install -y tmux expect
 
       - name: Install dependencies
         run: just install
@@ -31,4 +31,4 @@ jobs:
         run: just lint
 
       - name: Test
-        run: just test
+        run: unbuffer just test


### PR DESCRIPTION
## Summary
- Install `expect` package in CI (provides `unbuffer` command)
- Use `unbuffer just test` to allocate a pseudo-terminal for tmux tests
- This approach uses unbuffer from the expect package instead of the `script` command to provide a PTY in CI

## Context
Tmux requires a TTY to create sessions. CI environments typically don't provide one. The `unbuffer` command from the expect package can allocate a pseudo-terminal, allowing tmux to function properly.

## Test plan
- [ ] CI workflow runs successfully
- [ ] Tmux tests pass instead of being skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)