### PR TITLE
Add RALPH custom command archetype

### DIFF
--- a/docs/01-ux.md
+++ b/docs/01-ux.md
@@ -157,6 +157,12 @@ scope wait <id> [<id2> ...]
 # Blocks until complete. Returns: JSON {"results": [...]}
 ```
 
+### Custom Command: /ralph
+
+Use `/ralph` when you need an iterative critique → improve loop with explicit
+stopping criteria. It runs a requirements interview, then coordinates fresh
+subagents each iteration until the goal is met or gains taper off.
+
 ### Example
 ```bash
 id=$(scope spawn "Write tests for auth module" --input src/auth)

--- a/src/scope/commands/setup.py
+++ b/src/scope/commands/setup.py
@@ -11,6 +11,7 @@ from scope.core.tmux import is_installed as tmux_is_installed
 from scope.hooks.install import (
     install_ccstatusline,
     install_claude_md,
+    install_custom_commands,
     install_hooks,
 )
 
@@ -61,7 +62,12 @@ def setup() -> None:
     install_claude_md()
     click.echo("Documentation installed to ~/.claude/CLAUDE.md")
 
-    # 4. Install ccstatusline with context percentage
+    # 4. Install custom Claude Code commands
+    click.echo("Installing custom Claude Code commands...")
+    install_custom_commands()
+    click.echo("Custom commands installed to ~/.claude/commands")
+
+    # 5. Install ccstatusline with context percentage
     click.echo("Installing ccstatusline status bar...")
     install_ccstatusline()
     click.echo("Status bar configured to show context usage")


### PR DESCRIPTION
## Summary
- install a /ralph custom command via tmux found.
Installing scope hooks...
Hooks installed to ~/.claude/settings.json
Installing global documentation...
Documentation installed to ~/.claude/CLAUDE.md
Installing custom Claude Code commands...
Custom commands installed to ~/.claude/commands
Installing ccstatusline status bar...
Status bar configured to show context usage

Scope is now integrated with Claude Code.
Run 'scope' to start the TUI.
- document the RALPH archetype in global CLAUDE.md content
- add /ralph usage note to user docs

## Testing
- not run (docs/config only)