### PR TITLE
Skip tmux hook installation when no server is running

### DIFF
--- a/src/scope/core/tmux.py
+++ b/src/scope/core/tmux.py
@@ -79,6 +79,27 @@ def is_installed() -> bool:
         return False
 
 
+def is_server_running() -> bool:
+    """Check if a tmux server is running and reachable."""
+    try:
+        result = subprocess.run(
+            _tmux_cmd(["list-sessions"]),
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return False
+
+    if result.returncode == 0:
+        return True
+
+    stderr = (result.stderr or "").lower()
+    if "no server running" in stderr or "failed to connect to server" in stderr:
+        return False
+
+    return False
+
+
 def tmux_session_name(session_id: str) -> str:
     """Convert a scope session ID to a tmux session name.
 

--- a/src/scope/hooks/install.py
+++ b/src/scope/hooks/install.py
@@ -718,6 +718,7 @@ def ensure_setup(quiet: bool = True, force: bool = False) -> None:
         force: If True, force reinstall of all components (used by 'scope setup').
     """
     from scope.core.tmux import is_installed as tmux_is_installed
+    from scope.core.tmux import is_server_running
 
     # Skip if tmux not installed (can't do full setup)
     if not tmux_is_installed():
@@ -763,18 +764,22 @@ def ensure_setup(quiet: bool = True, force: bool = False) -> None:
     # Check and update tmux hooks
     tmux_ver = _tmux_hooks_version()
     if force or installed_versions.get("tmux_hooks") != tmux_ver:
-        try:
-            success, error = install_tmux_hooks()
-            if success:
-                installed_versions["tmux_hooks"] = tmux_ver
-                updated.append("tmux_hooks")
-            elif not quiet:
-                print(
-                    f"Warning: Failed to install tmux hooks: {error}", file=sys.stderr
-                )
-        except Exception as e:
-            if not quiet:
-                print(f"Warning: Failed to install tmux hooks: {e}", file=sys.stderr)
+        if is_server_running():
+            try:
+                success, error = install_tmux_hooks()
+                if success:
+                    installed_versions["tmux_hooks"] = tmux_ver
+                    updated.append("tmux_hooks")
+                elif not quiet:
+                    print(
+                        f"Warning: Failed to install tmux hooks: {error}",
+                        file=sys.stderr,
+                    )
+            except Exception as e:
+                if not quiet:
+                    print(
+                        f"Warning: Failed to install tmux hooks: {e}", file=sys.stderr
+                    )
 
     # Check and update ccstatusline (only if not already configured OR force)
     ccstatusline_ver = _ccstatusline_version()


### PR DESCRIPTION
## Summary
- Adds `is_server_running()` function to check if a tmux server is active
- Skips tmux hook installation in `ensure_setup()` when no server is running
- Prevents errors when tmux is installed but no sessions exist

## Test plan
- [ ] Run `scope` commands without an active tmux server - should not error
- [ ] Run `scope` commands with an active tmux server - hooks should install normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)