### PR TITLE
Make /scope bootstrap reliable + embed passive skill index

### DIFF
--- a/src/scope/commands/spawn.py
+++ b/src/scope/commands/spawn.py
@@ -290,6 +290,15 @@ def spawn(
             target = f":{window_name}"
         else:
             target = f"{get_scope_session()}:{window_name}"
+
+        # IMPORTANT: invoke /scope as its OWN message so Claude Code executes it
+        # as a command (instead of treating it as plain text inside a larger prompt).
+        try:
+            send_keys(target, "/scope", submit=True, verify=False)
+            time.sleep(0.3)
+        except TmuxError:
+            pass
+
         _send_contract(target, contract)
 
         # If the task is still pending, Enter may not have been delivered.

--- a/src/scope/core/contract.py
+++ b/src/scope/core/contract.py
@@ -20,8 +20,8 @@ def generate_contract(prompt: str, depends_on: list[str] | None = None) -> str:
     """
     sections = []
 
-    # Invoke /scope command to load orchestration rules
-    sections.append("/scope")
+    # NOTE: /scope is invoked separately by the spawner (Scope TUI / CLI)
+    # to ensure the command is executed as a command, not embedded in a larger prompt.
 
     # Add dependencies section if there are dependencies
     if depends_on:

--- a/src/scope/tui/app.py
+++ b/src/scope/tui/app.py
@@ -307,9 +307,10 @@ class ScopeApp(App):
             except TmuxError:
                 pass
 
-            # Prefill /scope command (without pressing Enter)
+            # Invoke /scope immediately as its own message.
+            # This is more reliable than embedding /scope inside a larger prompt.
             try:
-                send_keys(pane_id, "/scope ", submit=False)
+                send_keys(pane_id, "/scope", submit=True, verify=False)
             except TmuxError:
                 pass
         except TmuxError as e:


### PR DESCRIPTION
Implements two reliability improvements inspired by recent agent evals (Vercel: passive context beats optional retrieval).

0) Reliable /scope bootstrap
- Sends `/scope` as its own message before any task prompt (both `scope spawn` and TUI new session).
- Removes `/scope` from the generated contract so it’s not embedded inside a larger prompt.

1) Bootstrap the skill/pattern index into `/scope`
- Replaces the brittle "Skill tool with skill=…" instruction with a passive, always-present Pattern Selection table.
- The `/scope` command now contains a compact, actionable playbook (no separate tool invocation required).

Addresses common failure modes:
- "/scope doesn’t get triggered"
- "agents ignore skill invocation unless forced"

Files:
- src/scope/commands/spawn.py
- src/scope/tui/app.py
- src/scope/core/contract.py
- src/scope/hooks/install.py
