### PR TITLE
C2: Poll as Check-in, Wait as Result

### DIFF
--- a/.tickets/s-f087.md
+++ b/.tickets/s-f087.md
@@ -1,6 +1,6 @@
 ---
 id: s-f087
-status: open
+status: in_progress
 deps: []
 links: []
 created: 2026-01-29T19:18:28Z

--- a/tests/test_poll.py
+++ b/tests/test_poll.py
@@ -25,10 +25,10 @@ def test_poll_help(runner):
 
 
 def test_poll_no_args(runner):
-    """Test poll without session_id shows error."""
+    """Test poll without session_id or --all shows error."""
     result = runner.invoke(main, ["poll"])
-    assert result.exit_code != 0
-    assert "Missing argument" in result.output
+    assert result.exit_code == 1
+    assert "provide session IDs or use --all" in result.output
 
 
 def test_poll_session_not_found(runner, mock_scope_base):
@@ -40,7 +40,7 @@ def test_poll_session_not_found(runner, mock_scope_base):
 
 
 def test_poll_running_session(runner, mock_scope_base):
-    """Test poll returns status for running session."""
+    """Test poll returns compact status for running session."""
     session = Session(
         id="0",
         task="Test task",
@@ -56,6 +56,8 @@ def test_poll_running_session(runner, mock_scope_base):
     assert result.exit_code == 0
     data = orjson.loads(result.output)
     assert data["status"] == "running"
+    assert "elapsed" in data
+    assert "tool_calls" in data
 
 
 def test_poll_done_session(runner, mock_scope_base):
@@ -75,6 +77,7 @@ def test_poll_done_session(runner, mock_scope_base):
     assert result.exit_code == 0
     data = orjson.loads(result.output)
     assert data["status"] == "done"
+    assert "elapsed" in data
 
 
 def test_poll_with_activity(runner, mock_scope_base):
@@ -101,8 +104,8 @@ def test_poll_with_activity(runner, mock_scope_base):
     assert data["activity"] == "editing src/auth.ts"
 
 
-def test_poll_with_result(runner, mock_scope_base):
-    """Test poll returns result when session is done."""
+def test_poll_compact_no_result(runner, mock_scope_base):
+    """Test poll output does NOT include result text (use wait for that)."""
     session = Session(
         id="0",
         task="Test task",
@@ -122,7 +125,76 @@ def test_poll_with_result(runner, mock_scope_base):
     assert result.exit_code == 0
     data = orjson.loads(result.output)
     assert data["status"] == "done"
-    assert data["result"] == "Completed successfully. Updated 3 files."
+    # Poll should NOT include result text — that belongs to wait
+    assert "result" not in data
+
+
+def test_poll_elapsed_time(runner, mock_scope_base):
+    """Test poll includes elapsed time since session creation."""
+    session = Session(
+        id="0",
+        task="Test task",
+        parent="",
+        state="running",
+        tmux_session="scope-0",
+        created_at=datetime.now(timezone.utc),
+    )
+    save_session(session)
+
+    result = runner.invoke(main, ["poll", "0"])
+
+    assert result.exit_code == 0
+    data = orjson.loads(result.output)
+    # Elapsed should be a short string like "0s" or "1s"
+    assert "elapsed" in data
+    assert data["elapsed"].endswith("s")
+
+
+def test_poll_tool_calls_count(runner, mock_scope_base):
+    """Test poll includes tool call count from trajectory index."""
+    session = Session(
+        id="0",
+        task="Test task",
+        parent="",
+        state="running",
+        tmux_session="scope-0",
+        created_at=datetime.now(timezone.utc),
+    )
+    save_session(session)
+
+    # Write a trajectory index with tool calls
+    index_file = mock_scope_base / "sessions" / "0" / "trajectory_index.json"
+    index_data = {
+        "turn_count": 5,
+        "tool_calls": ["Read", "Grep", "Edit", "Read", "Bash"],
+        "tool_summary": {"Read": 2, "Grep": 1, "Edit": 1, "Bash": 1},
+    }
+    index_file.write_bytes(orjson.dumps(index_data))
+
+    result = runner.invoke(main, ["poll", "0"])
+
+    assert result.exit_code == 0
+    data = orjson.loads(result.output)
+    assert data["tool_calls"] == 5
+
+
+def test_poll_tool_calls_zero_without_index(runner, mock_scope_base):
+    """Test poll returns 0 tool calls when no trajectory index exists."""
+    session = Session(
+        id="0",
+        task="Test task",
+        parent="",
+        state="running",
+        tmux_session="scope-0",
+        created_at=datetime.now(timezone.utc),
+    )
+    save_session(session)
+
+    result = runner.invoke(main, ["poll", "0"])
+
+    assert result.exit_code == 0
+    data = orjson.loads(result.output)
+    assert data["tool_calls"] == 0
 
 
 def test_poll_child_session(runner, mock_scope_base):
@@ -185,3 +257,61 @@ def test_poll_evicted_activity_past_tense(runner, mock_scope_base):
     data = orjson.loads(result.output)
     assert data["status"] == "evicted"
     assert data["activity"] == "read src/auth.ts"
+
+
+def test_poll_all_sessions(runner, mock_scope_base):
+    """Test poll --all returns status for all sessions."""
+    for i in range(3):
+        session = Session(
+            id=str(i),
+            task=f"Task {i}",
+            parent="",
+            state="running" if i < 2 else "done",
+            tmux_session=f"scope-{i}",
+            created_at=datetime.now(timezone.utc),
+        )
+        save_session(session)
+
+    result = runner.invoke(main, ["poll", "--all"])
+
+    assert result.exit_code == 0
+    lines = result.output.strip().split("\n")
+    assert len(lines) == 3
+    for line in lines:
+        data = orjson.loads(line)
+        assert "id" in data
+        assert "status" in data
+        assert "elapsed" in data
+        assert "tool_calls" in data
+
+
+def test_poll_all_no_sessions(runner, mock_scope_base):
+    """Test poll --all with no sessions shows error."""
+    result = runner.invoke(main, ["poll", "--all"])
+
+    assert result.exit_code == 1
+    assert "No sessions found" in result.output
+
+
+def test_poll_one_line_per_session(runner, mock_scope_base):
+    """Test poll output is one JSON object per line (compact for orchestrator context)."""
+    for i in range(2):
+        session = Session(
+            id=str(i),
+            task=f"Task {i}",
+            parent="",
+            state="running",
+            tmux_session=f"scope-{i}",
+            created_at=datetime.now(timezone.utc),
+        )
+        save_session(session)
+
+    result = runner.invoke(main, ["poll", "0", "1"])
+
+    assert result.exit_code == 0
+    lines = result.output.strip().split("\n")
+    assert len(lines) == 2
+    # Each line should be valid JSON
+    for line in lines:
+        data = orjson.loads(line)
+        assert isinstance(data, dict)


### PR DESCRIPTION
## Summary

- **Poll** is now a lightweight, non-blocking check-in that returns compact status without bloating orchestrator context
- **Wait** remains the blocking call that returns full result text for decision-making
- Clear semantic distinction: poll = "how's it going?", wait = "give me the result"

## Changes

### Poll enhancements (`src/scope/commands/poll.py`)
- Added `--all` flag to poll all sessions at once (`scope poll --all`)
- Added `elapsed` field with human-readable elapsed time (e.g. `"5m30s"`)
- Added `tool_calls` count from trajectory index
- **Removed** `result` text from poll output — full results belong in `wait`
- Made `session_ids` optional when `--all` is used
- Extracted `_build_status()` helper for consistent status building

### Tests (`tests/test_poll.py`)
- 16 tests total (6 new): `--all`, elapsed time, tool call count, compact output (no result), one-line-per-session format, no-sessions error

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `scope poll <id>` returns lightweight status: running/done, elapsed time, tool call count, last activity | ✅ |
| 2 | `scope wait <id>` blocks until complete and returns full result text | ✅ (unchanged) |
| 3 | `scope poll --all` returns compact status of all active sessions | ✅ |
| 4 | Poll output concise enough to not bloat orchestrator context (one-line per session) | ✅ |
| 5 | Wait output contains full result for decision-making | ✅ (unchanged) |
| 6 | Clear semantic distinction: poll = check-in, wait = result | ✅ |

## Test plan

- [x] `pytest tests/test_poll.py tests/test_wait.py` — 36 tests pass
- [x] `ruff check src/` — all checks passed
- [x] Poll returns JSON with `id`, `status`, `elapsed`, `tool_calls`, optional `activity`
- [x] Poll does NOT return `result` field
- [x] Poll `--all` returns one line per session for all sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)