### PR TITLE
F3: Loop Termination

### DIFF
--- a/src/scope/cli.py
+++ b/src/scope/cli.py
@@ -12,6 +12,7 @@ import os
 import click
 
 from scope.commands.abort import abort
+from scope.commands.check_termination import check_termination
 from scope.commands.commit import advance, commit
 from scope.commands.poll import poll
 from scope.commands.resume import resume
@@ -128,6 +129,7 @@ def main(
 main.add_command(spawn)
 main.add_command(poll)
 main.add_command(abort)
+main.add_command(check_termination)
 main.add_command(commit)
 main.add_command(advance)
 main.add_command(resume)

--- a/src/scope/commands/check_termination.py
+++ b/src/scope/commands/check_termination.py
@@ -1,0 +1,106 @@
+"""Check-termination command for scope.
+
+Evaluates termination criteria for a session and outputs a recommendation.
+Designed for orchestrators to call after each iteration to decide whether
+to continue looping.
+"""
+
+import click
+import orjson
+
+from scope.core.state import ensure_scope_dir, resolve_id
+from scope.core.termination import (
+    evaluate_termination,
+    load_iteration_count,
+    load_max_iterations,
+    load_termination_criteria,
+    save_iteration_count,
+)
+
+
+@click.command("check-termination")
+@click.argument("session_id")
+@click.option(
+    "--increment",
+    is_flag=True,
+    help="Increment the iteration counter before checking",
+)
+@click.option(
+    "--json",
+    "output_json",
+    is_flag=True,
+    help="Output as JSON instead of human-readable summary",
+)
+def check_termination(session_id: str, increment: bool, output_json: bool) -> None:
+    """Check termination criteria for a session.
+
+    Runs all termination criteria and outputs a recommendation:
+    terminate or iterate. The orchestrator retains authority to override.
+
+    Exit codes: 0 = recommend terminate, 1 = error, 2 = recommend iterate.
+
+    Examples:
+
+        scope check-termination 0
+
+        scope check-termination --increment 0
+
+        scope check-termination --json 0
+    """
+    resolved = resolve_id(session_id)
+    if resolved is None:
+        click.echo(f"Session {session_id} not found", err=True)
+        raise SystemExit(1)
+
+    scope_dir = ensure_scope_dir()
+    session_dir = scope_dir / "sessions" / resolved
+
+    criteria = load_termination_criteria(session_dir)
+    if criteria is None:
+        click.echo(
+            f"No termination criteria set for session {session_id}\n"
+            f"  Fix: Spawn with --terminate-when to set criteria:\n"
+            f'    scope spawn --terminate-when "pytest tests/" "your prompt"',
+            err=True,
+        )
+        raise SystemExit(1)
+
+    # Optionally increment iteration counter
+    if increment:
+        current = load_iteration_count(session_dir)
+        save_iteration_count(session_dir, current + 1)
+
+    iteration = load_iteration_count(session_dir)
+    max_iter = load_max_iterations(session_dir)
+
+    result = evaluate_termination(
+        criteria=criteria,
+        iteration=iteration,
+        max_iterations=max_iter,
+    )
+
+    if output_json:
+        data = {
+            "session": resolved,
+            "iteration": result.iteration,
+            "max_iterations": result.max_iterations,
+            "recommend_terminate": result.recommend_terminate,
+            "reason": result.reason,
+            "checks": [
+                {
+                    "criterion": c.criterion,
+                    "passed": c.passed,
+                    "detail": c.detail,
+                }
+                for c in result.checks
+            ],
+        }
+        click.echo(orjson.dumps(data).decode())
+    else:
+        click.echo(result.summary())
+
+    # Exit code signals recommendation: 0=terminate, 2=iterate
+    if result.recommend_terminate:
+        raise SystemExit(0)
+    else:
+        raise SystemExit(2)

--- a/src/scope/core/contract.py
+++ b/src/scope/core/contract.py
@@ -24,6 +24,8 @@ def generate_contract(
     file_scope: list[str] | None = None,
     verify: list[str] | None = None,
     pattern: str | None = None,
+    termination: list[str] | None = None,
+    max_iterations: int | None = None,
 ) -> str:
     """Generate a contract markdown for a session.
 
@@ -40,6 +42,8 @@ def generate_contract(
         file_scope: Optional list of file/directory constraints.
         verify: Optional list of verification criteria (natural language or commands).
         pattern: Optional pattern commitment (e.g., 'tdd', 'ralph').
+        termination: Optional list of termination criteria for loop control.
+        max_iterations: Optional max iteration bound for loop control.
 
     Returns:
         Markdown string containing the contract.
@@ -111,6 +115,18 @@ def generate_contract(
         sections.append(
             f"# Verification\n\n"
             f"Your output will be verified against these criteria:\n{checks}"
+        )
+
+    # Add termination criteria section
+    if termination:
+        criteria = "\n".join(f"- {c}" for c in termination)
+        bound = f" (max {max_iterations} iterations)" if max_iterations else ""
+        sections.append(
+            f"# Termination Criteria\n\n"
+            f"This session is part of a feedback loop{bound}. "
+            f"The loop completes when:\n{criteria}\n\n"
+            f"After each iteration, these criteria will be checked and the orchestrator "
+            f"will receive a recommendation to terminate or continue."
         )
 
     return "\n\n".join(sections)

--- a/src/scope/core/termination.py
+++ b/src/scope/core/termination.py
@@ -1,0 +1,256 @@
+"""Termination criteria evaluation for feedback loops.
+
+Provides mechanism to check whether an iteration loop should terminate
+based on verification criteria results. The orchestrator retains authority
+to override recommendations — Scope provides signals, not enforcement.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class TerminationCheck:
+    """Result of checking a single criterion."""
+
+    criterion: str
+    passed: bool
+    detail: str = ""
+
+
+@dataclass
+class TerminationResult:
+    """Result of evaluating all termination criteria for an iteration."""
+
+    checks: list[TerminationCheck]
+    iteration: int
+    max_iterations: int
+    recommend_terminate: bool
+    reason: str
+
+    def summary(self) -> str:
+        """Format a human-readable summary of the termination evaluation."""
+        parts: list[str] = []
+
+        parts.append(f"Iteration {self.iteration}/{self.max_iterations}")
+        parts.append("")
+
+        for check in self.checks:
+            status = "PASS" if check.passed else "FAIL"
+            line = f"  [{status}] {check.criterion}"
+            if check.detail:
+                line += f" — {check.detail}"
+            parts.append(line)
+
+        parts.append("")
+        if self.recommend_terminate:
+            parts.append(f"Recommendation: TERMINATE — {self.reason}")
+        else:
+            parts.append(f"Recommendation: ITERATE — {self.reason}")
+
+        return "\n".join(parts)
+
+
+def run_criterion(criterion: str, cwd: Path | None = None) -> TerminationCheck:
+    """Run a single termination criterion.
+
+    If the criterion looks like a shell command (contains common command
+    patterns), it is executed as a subprocess. Otherwise it is treated
+    as a descriptive criterion that cannot be automatically checked.
+
+    Args:
+        criterion: The criterion string — either a command or description.
+        cwd: Working directory for command execution.
+
+    Returns:
+        TerminationCheck with pass/fail result.
+    """
+    if _is_command(criterion):
+        return _run_command_criterion(criterion, cwd)
+    return TerminationCheck(
+        criterion=criterion,
+        passed=False,
+        detail="descriptive criterion — cannot be automatically verified",
+    )
+
+
+def _is_command(criterion: str) -> bool:
+    """Heuristic: does this criterion look like a shell command?"""
+    # Common command prefixes and patterns
+    command_indicators = [
+        "pytest", "ruff", "mypy", "black", "cargo", "npm", "make",
+        "go ", "python", "node", "bash", "sh ", "test ", "./",
+    ]
+    lower = criterion.lower().strip()
+    return any(lower.startswith(prefix) for prefix in command_indicators)
+
+
+def _run_command_criterion(criterion: str, cwd: Path | None = None) -> TerminationCheck:
+    """Execute a criterion as a shell command and check exit code."""
+    try:
+        result = subprocess.run(
+            criterion,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            cwd=cwd,
+        )
+        passed = result.returncode == 0
+        detail = ""
+        if not passed:
+            # Capture last line of stderr or stdout for context
+            output = result.stderr.strip() or result.stdout.strip()
+            if output:
+                lines = output.splitlines()
+                detail = lines[-1][:200]
+        return TerminationCheck(criterion=criterion, passed=passed, detail=detail)
+    except subprocess.TimeoutExpired:
+        return TerminationCheck(
+            criterion=criterion, passed=False, detail="command timed out"
+        )
+    except OSError as e:
+        return TerminationCheck(
+            criterion=criterion, passed=False, detail=f"execution error: {e}"
+        )
+
+
+def evaluate_termination(
+    criteria: list[str],
+    iteration: int,
+    max_iterations: int,
+    cwd: Path | None = None,
+) -> TerminationResult:
+    """Evaluate termination criteria and produce a recommendation.
+
+    Runs all criteria checks and determines whether to recommend
+    termination or continued iteration.
+
+    Args:
+        criteria: List of termination criteria (commands or descriptions).
+        iteration: Current iteration number (1-based).
+        max_iterations: Maximum allowed iterations.
+        cwd: Working directory for command execution.
+
+    Returns:
+        TerminationResult with checks, recommendation, and reason.
+    """
+    checks = [run_criterion(c, cwd=cwd) for c in criteria]
+
+    all_passed = all(c.passed for c in checks)
+    at_max = iteration >= max_iterations
+
+    if all_passed:
+        return TerminationResult(
+            checks=checks,
+            iteration=iteration,
+            max_iterations=max_iterations,
+            recommend_terminate=True,
+            reason="all criteria passed",
+        )
+
+    if at_max:
+        failed = [c.criterion for c in checks if not c.passed]
+        return TerminationResult(
+            checks=checks,
+            iteration=iteration,
+            max_iterations=max_iterations,
+            recommend_terminate=True,
+            reason=f"max iterations ({max_iterations}) reached; still failing: {', '.join(failed)}",
+        )
+
+    failed = [c.criterion for c in checks if not c.passed]
+    return TerminationResult(
+        checks=checks,
+        iteration=iteration,
+        max_iterations=max_iterations,
+        recommend_terminate=False,
+        reason=f"criteria not met: {', '.join(failed)}",
+    )
+
+
+def load_termination_criteria(session_dir: Path) -> list[str] | None:
+    """Load termination criteria from a session directory.
+
+    Args:
+        session_dir: Path to the session directory.
+
+    Returns:
+        List of criteria strings, or None if not set.
+    """
+    criteria_file = session_dir / "termination_criteria"
+    if not criteria_file.exists():
+        return None
+    content = criteria_file.read_text().strip()
+    if not content:
+        return None
+    return content.splitlines()
+
+
+def save_termination_criteria(session_dir: Path, criteria: list[str]) -> None:
+    """Save termination criteria to a session directory.
+
+    Args:
+        session_dir: Path to the session directory.
+        criteria: List of criteria strings.
+    """
+    (session_dir / "termination_criteria").write_text("\n".join(criteria))
+
+
+def load_max_iterations(session_dir: Path) -> int:
+    """Load max iterations bound from a session directory.
+
+    Args:
+        session_dir: Path to the session directory.
+
+    Returns:
+        Max iterations value, defaults to 10 if not set.
+    """
+    max_iter_file = session_dir / "max_iterations"
+    if max_iter_file.exists():
+        try:
+            return int(max_iter_file.read_text().strip())
+        except ValueError:
+            pass
+    return 10
+
+
+def save_max_iterations(session_dir: Path, max_iterations: int) -> None:
+    """Save max iterations bound to a session directory.
+
+    Args:
+        session_dir: Path to the session directory.
+        max_iterations: Maximum iteration count.
+    """
+    (session_dir / "max_iterations").write_text(str(max_iterations))
+
+
+def load_iteration_count(session_dir: Path) -> int:
+    """Load current iteration count from a session directory.
+
+    Args:
+        session_dir: Path to the session directory.
+
+    Returns:
+        Current iteration count, defaults to 0 if not set.
+    """
+    iter_file = session_dir / "iteration"
+    if iter_file.exists():
+        try:
+            return int(iter_file.read_text().strip())
+        except ValueError:
+            pass
+    return 0
+
+
+def save_iteration_count(session_dir: Path, iteration: int) -> None:
+    """Save current iteration count to a session directory.
+
+    Args:
+        session_dir: Path to the session directory.
+        iteration: Current iteration number.
+    """
+    (session_dir / "iteration").write_text(str(iteration))

--- a/tests/test_termination.py
+++ b/tests/test_termination.py
@@ -1,0 +1,489 @@
+"""Tests for loop termination criteria and evaluation."""
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from scope.core.contract import generate_contract
+from scope.core.termination import (
+    TerminationCheck,
+    TerminationResult,
+    evaluate_termination,
+    load_iteration_count,
+    load_max_iterations,
+    load_termination_criteria,
+    run_criterion,
+    save_iteration_count,
+    save_max_iterations,
+    save_termination_criteria,
+)
+
+
+# --- Termination criteria specification (AC1) ---
+
+
+class TestTerminationCriteriaSpecification:
+    """Termination criteria can be specified in the contract or skill."""
+
+    def test_contract_includes_termination_criteria(self):
+        """Contract includes termination criteria section."""
+        contract = generate_contract(
+            prompt="Implement feature",
+            termination=["pytest tests/", "ruff check src/"],
+        )
+
+        assert "# Termination Criteria" in contract
+        assert "- pytest tests/" in contract
+        assert "- ruff check src/" in contract
+        assert "feedback loop" in contract
+
+    def test_contract_includes_max_iterations(self):
+        """Contract includes max iterations bound."""
+        contract = generate_contract(
+            prompt="Implement feature",
+            termination=["pytest tests/"],
+            max_iterations=5,
+        )
+
+        assert "max 5 iterations" in contract
+
+    def test_contract_no_termination_when_none(self):
+        """No termination section when criteria is None."""
+        contract = generate_contract(prompt="Do work", termination=None)
+
+        assert "# Termination Criteria" not in contract
+
+    def test_contract_no_termination_when_empty(self):
+        """No termination section when criteria is empty."""
+        contract = generate_contract(prompt="Do work", termination=[])
+
+        assert "# Termination Criteria" not in contract
+
+    def test_contract_termination_after_verification(self):
+        """Termination section comes after verification."""
+        contract = generate_contract(
+            prompt="Do work",
+            verify=["pytest"],
+            termination=["pytest tests/"],
+        )
+
+        assert contract.index("# Verification") < contract.index(
+            "# Termination Criteria"
+        )
+
+    def test_contract_full_ordering_with_termination(self):
+        """All sections including termination appear in correct order."""
+        contract = generate_contract(
+            prompt="Implement feature",
+            depends_on=["0.0"],
+            phase="GREEN",
+            parent_intent="Build the auth system",
+            prior_results=["Previous research completed."],
+            file_scope=["src/auth/"],
+            verify=["pytest"],
+            termination=["pytest tests/", "ruff check"],
+            max_iterations=3,
+        )
+
+        deps_idx = contract.index("# Dependencies")
+        phase_idx = contract.index("# Phase")
+        intent_idx = contract.index("# Parent Intent")
+        results_idx = contract.index("# Prior Results")
+        task_idx = contract.index("# Task")
+        scope_idx = contract.index("# File Scope")
+        verify_idx = contract.index("# Verification")
+        term_idx = contract.index("# Termination Criteria")
+
+        assert (
+            deps_idx
+            < phase_idx
+            < intent_idx
+            < results_idx
+            < task_idx
+            < scope_idx
+            < verify_idx
+            < term_idx
+        )
+
+    def test_save_and_load_termination_criteria(self, tmp_path):
+        """Termination criteria can be saved and loaded from session dir."""
+        criteria = ["pytest tests/", "ruff check src/"]
+        save_termination_criteria(tmp_path, criteria)
+
+        loaded = load_termination_criteria(tmp_path)
+        assert loaded == criteria
+
+    def test_load_termination_criteria_not_set(self, tmp_path):
+        """Returns None when no criteria file exists."""
+        loaded = load_termination_criteria(tmp_path)
+        assert loaded is None
+
+    def test_load_termination_criteria_empty_file(self, tmp_path):
+        """Returns None when criteria file is empty."""
+        (tmp_path / "termination_criteria").write_text("")
+        loaded = load_termination_criteria(tmp_path)
+        assert loaded is None
+
+
+# --- Criteria checking after each iteration (AC2) ---
+
+
+class TestCriteriaChecking:
+    """After each iteration, Scope runs verification and checks against criteria."""
+
+    def test_run_command_criterion_passing(self, tmp_path):
+        """A passing command criterion returns passed=True."""
+        check = run_criterion("python -c 'exit(0)'", cwd=tmp_path)
+        assert check.passed is True
+        assert check.criterion == "python -c 'exit(0)'"
+
+    def test_run_command_criterion_failing(self, tmp_path):
+        """A failing command criterion returns passed=False."""
+        check = run_criterion("python -c 'exit(1)'", cwd=tmp_path)
+        assert check.passed is False
+
+    def test_run_command_criterion_with_error_detail(self, tmp_path):
+        """A failing command captures error detail."""
+        check = run_criterion(
+            "python -c 'import sys; print(\"oops\", file=sys.stderr); exit(1)'",
+            cwd=tmp_path,
+        )
+        assert check.passed is False
+        assert "oops" in check.detail
+
+    def test_descriptive_criterion_not_auto_verified(self):
+        """Descriptive criteria cannot be automatically verified."""
+        check = run_criterion("all types pass")
+        assert check.passed is False
+        assert "descriptive" in check.detail
+
+    def test_evaluate_all_passing(self, tmp_path):
+        """All criteria passing produces terminate recommendation."""
+        result = evaluate_termination(
+            criteria=["python -c 'exit(0)'"],
+            iteration=1,
+            max_iterations=5,
+            cwd=tmp_path,
+        )
+        assert result.recommend_terminate is True
+        assert "all criteria passed" in result.reason
+
+    def test_evaluate_some_failing(self, tmp_path):
+        """Some criteria failing produces iterate recommendation."""
+        result = evaluate_termination(
+            criteria=["python -c 'exit(0)'", "python -c 'exit(1)'"],
+            iteration=1,
+            max_iterations=5,
+            cwd=tmp_path,
+        )
+        assert result.recommend_terminate is False
+        assert "criteria not met" in result.reason
+
+    def test_iteration_counter_persistence(self, tmp_path):
+        """Iteration counter can be saved and loaded."""
+        assert load_iteration_count(tmp_path) == 0
+
+        save_iteration_count(tmp_path, 3)
+        assert load_iteration_count(tmp_path) == 3
+
+        save_iteration_count(tmp_path, 4)
+        assert load_iteration_count(tmp_path) == 4
+
+
+# --- Recommendation messages (AC3) ---
+
+
+class TestRecommendationMessages:
+    """Orchestrator receives explicit recommendation to terminate or iterate."""
+
+    def test_terminate_recommendation_all_pass(self, tmp_path):
+        """Criteria met produces 'criteria met, recommend terminate'."""
+        result = evaluate_termination(
+            criteria=["python -c 'exit(0)'"],
+            iteration=1,
+            max_iterations=5,
+            cwd=tmp_path,
+        )
+        assert result.recommend_terminate is True
+        summary = result.summary()
+        assert "TERMINATE" in summary
+        assert "all criteria passed" in summary
+
+    def test_iterate_recommendation_criteria_not_met(self, tmp_path):
+        """Criteria not met produces 'criteria not met, recommend iterate'."""
+        result = evaluate_termination(
+            criteria=["python -c 'exit(1)'"],
+            iteration=1,
+            max_iterations=5,
+            cwd=tmp_path,
+        )
+        assert result.recommend_terminate is False
+        summary = result.summary()
+        assert "ITERATE" in summary
+        assert "criteria not met" in summary
+
+    def test_summary_includes_iteration_info(self, tmp_path):
+        """Summary includes iteration count."""
+        result = evaluate_termination(
+            criteria=["python -c 'exit(0)'"],
+            iteration=3,
+            max_iterations=5,
+            cwd=tmp_path,
+        )
+        assert "3/5" in result.summary()
+
+    def test_summary_includes_check_results(self, tmp_path):
+        """Summary includes individual check results."""
+        result = evaluate_termination(
+            criteria=["python -c 'exit(0)'", "python -c 'exit(1)'"],
+            iteration=1,
+            max_iterations=5,
+            cwd=tmp_path,
+        )
+        summary = result.summary()
+        assert "[PASS]" in summary
+        assert "[FAIL]" in summary
+
+    def test_terminate_at_max_with_failures(self, tmp_path):
+        """At max iterations, recommend terminate even with failures."""
+        result = evaluate_termination(
+            criteria=["python -c 'exit(1)'"],
+            iteration=5,
+            max_iterations=5,
+            cwd=tmp_path,
+        )
+        assert result.recommend_terminate is True
+        assert "max iterations" in result.reason
+        summary = result.summary()
+        assert "TERMINATE" in summary
+
+
+# --- Max iteration bounds (AC4) ---
+
+
+class TestMaxIterationBounds:
+    """Max iteration bounds prevent infinite loops."""
+
+    def test_max_iterations_default(self, tmp_path):
+        """Default max iterations is 10."""
+        assert load_max_iterations(tmp_path) == 10
+
+    def test_max_iterations_save_and_load(self, tmp_path):
+        """Max iterations can be saved and loaded."""
+        save_max_iterations(tmp_path, 5)
+        assert load_max_iterations(tmp_path) == 5
+
+    def test_terminate_at_max_iterations(self, tmp_path):
+        """Reaching max iterations recommends terminate regardless."""
+        result = evaluate_termination(
+            criteria=["python -c 'exit(1)'"],
+            iteration=10,
+            max_iterations=10,
+            cwd=tmp_path,
+        )
+        assert result.recommend_terminate is True
+        assert "max iterations" in result.reason
+
+    def test_does_not_terminate_before_max(self, tmp_path):
+        """Before max iterations, failing criteria recommends iterate."""
+        result = evaluate_termination(
+            criteria=["python -c 'exit(1)'"],
+            iteration=9,
+            max_iterations=10,
+            cwd=tmp_path,
+        )
+        assert result.recommend_terminate is False
+
+    def test_max_iterations_invalid_file(self, tmp_path):
+        """Invalid max_iterations file falls back to default."""
+        (tmp_path / "max_iterations").write_text("not a number")
+        assert load_max_iterations(tmp_path) == 10
+
+    def test_iteration_count_invalid_file(self, tmp_path):
+        """Invalid iteration file falls back to 0."""
+        (tmp_path / "iteration").write_text("not a number")
+        assert load_iteration_count(tmp_path) == 0
+
+
+# --- Orchestrator override authority (AC5) ---
+
+
+class TestOrchestratorOverride:
+    """Orchestrator retains authority to override termination recommendations."""
+
+    def test_result_is_recommendation_not_enforcement(self, tmp_path):
+        """TerminationResult provides recommendation, not enforcement."""
+        result = evaluate_termination(
+            criteria=["python -c 'exit(0)'"],
+            iteration=1,
+            max_iterations=5,
+            cwd=tmp_path,
+        )
+        # The result is a data object — orchestrator decides what to do with it
+        assert isinstance(result.recommend_terminate, bool)
+        assert isinstance(result.reason, str)
+        assert isinstance(result.checks, list)
+        # Summary uses "Recommendation:" not "Decision:" or "Action:"
+        assert "Recommendation:" in result.summary()
+
+    def test_check_termination_exit_codes(self, mock_scope_base):
+        """check-termination command uses exit codes for scripting."""
+        from scope.commands.check_termination import check_termination
+
+        runner = CliRunner()
+
+        # Create a session with termination criteria
+        session_dir = mock_scope_base / "sessions" / "0"
+        session_dir.mkdir(parents=True)
+        (session_dir / "task").write_text("test task")
+        (session_dir / "state").write_text("running")
+        (session_dir / "parent").write_text("")
+        (session_dir / "tmux").write_text("scope-0")
+        (session_dir / "created_at").write_text("2024-01-01T00:00:00")
+        (session_dir / "alias").write_text("")
+
+        save_termination_criteria(session_dir, ["python -c 'exit(0)'"])
+        save_max_iterations(session_dir, 5)
+        save_iteration_count(session_dir, 1)
+
+        # Exit code 0 = recommend terminate (all pass)
+        result = runner.invoke(check_termination, ["0"])
+        assert result.exit_code == 0
+
+    def test_check_termination_iterate_exit_code(self, mock_scope_base):
+        """check-termination returns exit code 2 for iterate recommendation."""
+        from scope.commands.check_termination import check_termination
+
+        runner = CliRunner()
+
+        session_dir = mock_scope_base / "sessions" / "0"
+        session_dir.mkdir(parents=True)
+        (session_dir / "task").write_text("test task")
+        (session_dir / "state").write_text("running")
+        (session_dir / "parent").write_text("")
+        (session_dir / "tmux").write_text("scope-0")
+        (session_dir / "created_at").write_text("2024-01-01T00:00:00")
+        (session_dir / "alias").write_text("")
+
+        save_termination_criteria(session_dir, ["python -c 'exit(1)'"])
+        save_max_iterations(session_dir, 5)
+        save_iteration_count(session_dir, 1)
+
+        # Exit code 2 = recommend iterate (criteria not met)
+        result = runner.invoke(check_termination, ["0"])
+        assert result.exit_code == 2
+
+    def test_check_termination_increment(self, mock_scope_base):
+        """--increment flag advances the iteration counter."""
+        from scope.commands.check_termination import check_termination
+
+        runner = CliRunner()
+
+        session_dir = mock_scope_base / "sessions" / "0"
+        session_dir.mkdir(parents=True)
+        (session_dir / "task").write_text("test task")
+        (session_dir / "state").write_text("running")
+        (session_dir / "parent").write_text("")
+        (session_dir / "tmux").write_text("scope-0")
+        (session_dir / "created_at").write_text("2024-01-01T00:00:00")
+        (session_dir / "alias").write_text("")
+
+        save_termination_criteria(session_dir, ["python -c 'exit(0)'"])
+        save_max_iterations(session_dir, 5)
+        save_iteration_count(session_dir, 0)
+
+        runner.invoke(check_termination, ["--increment", "0"])
+
+        assert load_iteration_count(session_dir) == 1
+
+    def test_check_termination_json_output(self, mock_scope_base):
+        """--json flag outputs machine-readable JSON."""
+        import orjson
+
+        from scope.commands.check_termination import check_termination
+
+        runner = CliRunner()
+
+        session_dir = mock_scope_base / "sessions" / "0"
+        session_dir.mkdir(parents=True)
+        (session_dir / "task").write_text("test task")
+        (session_dir / "state").write_text("running")
+        (session_dir / "parent").write_text("")
+        (session_dir / "tmux").write_text("scope-0")
+        (session_dir / "created_at").write_text("2024-01-01T00:00:00")
+        (session_dir / "alias").write_text("")
+
+        save_termination_criteria(session_dir, ["python -c 'exit(0)'"])
+        save_max_iterations(session_dir, 5)
+        save_iteration_count(session_dir, 1)
+
+        result = runner.invoke(check_termination, ["--json", "0"])
+        data = orjson.loads(result.output)
+
+        assert data["session"] == "0"
+        assert data["recommend_terminate"] is True
+        assert data["iteration"] == 1
+        assert data["max_iterations"] == 5
+        assert len(data["checks"]) == 1
+
+    def test_check_termination_no_criteria_error(self, mock_scope_base):
+        """Error when no termination criteria set."""
+        from scope.commands.check_termination import check_termination
+
+        runner = CliRunner()
+
+        session_dir = mock_scope_base / "sessions" / "0"
+        session_dir.mkdir(parents=True)
+        (session_dir / "task").write_text("test task")
+        (session_dir / "state").write_text("running")
+        (session_dir / "parent").write_text("")
+        (session_dir / "tmux").write_text("scope-0")
+        (session_dir / "created_at").write_text("2024-01-01T00:00:00")
+        (session_dir / "alias").write_text("")
+
+        result = runner.invoke(check_termination, ["0"])
+        assert result.exit_code == 1
+        assert "No termination criteria" in result.output
+
+
+# --- Command heuristic detection ---
+
+
+class TestCommandDetection:
+    """Test the command vs descriptive criterion heuristic."""
+
+    def test_pytest_is_command(self, tmp_path):
+        """pytest is detected as a command."""
+        check = run_criterion("pytest tests/", cwd=tmp_path)
+        # It should attempt to run it (may fail if pytest not found via shell)
+        assert check.criterion == "pytest tests/"
+
+    def test_ruff_is_command(self, tmp_path):
+        """ruff is detected as a command."""
+        check = run_criterion("ruff check src/", cwd=tmp_path)
+        assert check.criterion == "ruff check src/"
+
+    def test_natural_language_is_descriptive(self):
+        """Natural language is treated as descriptive."""
+        check = run_criterion("all tests pass and lint is clean")
+        assert check.passed is False
+        assert "descriptive" in check.detail
+
+    def test_make_is_command(self, tmp_path):
+        """make is detected as a command."""
+        check = run_criterion("make test", cwd=tmp_path)
+        assert check.criterion == "make test"
+
+    def test_npm_is_command(self, tmp_path):
+        """npm is detected as a command."""
+        check = run_criterion("npm test", cwd=tmp_path)
+        assert check.criterion == "npm test"
+
+    def test_script_path_is_command(self, tmp_path):
+        """./script.sh is detected as a command."""
+        script = tmp_path / "test.sh"
+        script.write_text("#!/bin/sh\nexit 0\n")
+        script.chmod(0o755)
+        check = run_criterion("./test.sh", cwd=tmp_path)
+        assert check.passed is True


### PR DESCRIPTION
## Summary

- **Termination criteria specification**: `--terminate-when` flag on `scope spawn` accepts comma-separated criteria (commands or descriptions) that define when a loop should stop. Criteria are embedded in the contract and persisted to `termination_criteria` file.
- **Criteria checking**: `scope check-termination <id>` evaluates all criteria by running command-based checks (exit code 0 = pass) and reports results. Descriptive criteria are flagged as not auto-verifiable.
- **Explicit recommendations**: Each evaluation produces "Recommendation: TERMINATE — all criteria passed" or "Recommendation: ITERATE — criteria not met: ..." with per-check PASS/FAIL breakdown.
- **Max iteration bounds**: `--max-iterations N` (default 10) prevents infinite loops. At max iterations, termination is recommended regardless of criteria status.
- **Orchestrator override**: Results are recommendations, not enforcement. Exit codes (0=terminate, 2=iterate) enable scripting. JSON output via `--json` for programmatic consumption.

## New files
- `src/scope/core/termination.py` — Core evaluation logic, criteria persistence
- `src/scope/commands/check_termination.py` — `scope check-termination` command
- `tests/test_termination.py` — 39 tests covering all acceptance criteria

## Modified files
- `src/scope/core/contract.py` — `termination` and `max_iterations` params in contract generation
- `src/scope/commands/spawn.py` — `--terminate-when` and `--max-iterations` flags
- `src/scope/commands/poll.py` — `--check-termination` flag for inline evaluation
- `src/scope/cli.py` — Register `check-termination` command

## Acceptance Criteria

| # | Criterion | How Met |
|---|-----------|---------|
| 1 | Termination criteria specified in contract/skill | `--terminate-when` on spawn, embedded in contract markdown |
| 2 | Verification checked after each iteration | `scope check-termination` runs criteria and reports results |
| 3 | Explicit recommendation messages | "Recommendation: TERMINATE/ITERATE — reason" in summary output |
| 4 | Max iteration bounds | `--max-iterations N` (default 10), forces terminate at bound |
| 5 | Orchestrator retains override authority | Results are data/recommendations, not enforcement; exit codes for scripting |

## Test plan
- [x] `pytest tests/test_termination.py` — 39 tests pass
- [x] `pytest tests/` — All 402 tests pass
- [x] `ruff check src/` — Clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)